### PR TITLE
Remove manual watermark removal UI from popup

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -3,43 +3,25 @@
 <head>
     <meta charset="UTF-8">
     <title>ClearMark</title>
-<style>
-    body {
-        width: 200px;
-        padding: 15px;
-        font-family: system-ui, -apple-system, sans-serif;
-        background-color: #ffffff;
-        margin: 0;
-    }
-    
-    .container {
-        display: flex;
-        justify-content: center;
-    }
-    
-    #toggle-watermark {
-        background-color: #3498db;
-        color: white;
-        border: none;
-        padding: 10px 20px;
-        text-align: center;
-        font-size: 14px;
-        font-weight: 500;
-        cursor: pointer;
-        border-radius: 6px;
-        transition: background-color 0.2s ease;
-        width: 100%;
-    }
-    
-    #toggle-watermark:hover {
-        background-color: #2980b9;
-    }
-</style>
+    <style>
+        body {
+            width: 200px;
+            padding: 15px;
+            font-family: system-ui, -apple-system, sans-serif;
+            background-color: #ffffff;
+            margin: 0;
+        }
+
+        .status {
+            text-align: center;
+            font-size: 14px;
+            font-weight: 500;
+            color: #3498db;
+        }
+    </style>
 </head>
 <body>
-    <div class="container">
-        <button id="toggle-watermark">Remove Watermark</button>
-    </div>
+    <div class="status" id="status">Watermark: Hidden</div>
     <script src="popup.js"></script>
 </body>
 </html>


### PR DESCRIPTION
- Removed the "Remove Watermark" button from popup.html since the process is now automated.
- Simplified popup.js to only display the watermark status (hidden/visible).
- Updated the UI to reflect the current state of the watermark without requiring user interaction.